### PR TITLE
Corrected spelling of Ahmedabad

### DIFF
--- a/state_district_wise.json
+++ b/state_district_wise.json
@@ -1316,7 +1316,7 @@
           "confirmed": 0
         }
       },
-      "Ahmadabad": {
+      "Ahmedabad": {
         "confirmed": 31,
         "lastupdatedtime": "",
         "delta": {


### PR DESCRIPTION
I've corrected spelling of Ahmedabad from Ahmadabad 