### PR TITLE
Typo in District

### DIFF
--- a/state_district_wise.json
+++ b/state_district_wise.json
@@ -1385,7 +1385,7 @@
           "confirmed": 1
         }
       },
-      "Ahmadnagar": {
+      "Ahmednagar": {
         "confirmed": 28,
         "lastupdatedtime": "",
         "delta": {


### PR DESCRIPTION
Issue from https://github.com/covid19india/covid19india-react/issues/845
Correction  'Ahmadnagar' to 'Ahmednagar'