### PR TITLE
Request to add website which predicts COVID19 cases

### DIFF
--- a/projects/analysis.md
+++ b/projects/analysis.md
@@ -12,3 +12,8 @@
 
 - [R-naught stats for India](https://www.rt-india.live/)
     - By: [@rohit](https://t.me/rohitxsh)
+    
+---
+
+- [Covid19 India Predictions and Stats](https://ncov19stats.herokuapp.com)
+    - By: [Naveen](https://www.github.com/naveensaigit)


### PR DESCRIPTION
I have added https://ncov19stats.herokuapp.com, a website which uses covid19india api to predict cases and provides useful statistics.